### PR TITLE
Fix HTML script tag source reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@ index 0000000000000000000000000000000000000000..b7832eb04e95911fc32b5afa15324a41
 +    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 +    <title>HSR Build Planner</title>
 +    <link rel="stylesheet" href="styles.css" />
-+    <script defer src="scripts.js"></script>
++    <script defer src="script.js"></script>
 +  </head>
 +  <body>
 +    <header>


### PR DESCRIPTION
## Summary
- update the index page to point the defer script tag at the existing script.js file

## Testing
- manual: loaded http://127.0.0.1:8000/index.html and confirmed script.js was requested successfully

------
https://chatgpt.com/codex/tasks/task_e_68d7b45227048329beb694e2d49ec655