### PR TITLE
Fix character path description grammar

### DIFF
--- a/script.js
+++ b/script.js
@@ -77,7 +77,7 @@ function updateCharacterDetails(value) {
   const description = document.getElementById("character-description");
   if (description) {
     description.textContent = details
-      ? `${value} follows the Path of the ${details.path}. ${details.description}`
+      ? `${value} follows the Path of ${details.path}. ${details.description}`
       : "";
   }
 }


### PR DESCRIPTION
## Summary
- remove the extra "the" in the character path description string so it reads "Path of X"

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7ba7e9d2883298f91731c5d549be7